### PR TITLE
fix: make LRUCache thread safe

### DIFF
--- a/lru_cache.go
+++ b/lru_cache.go
@@ -2,9 +2,11 @@ package ldevents
 
 import (
 	"container/list"
+	"sync"
 )
 
 type lruCache struct {
+	m        sync.RWMutex
 	values   map[interface{}]*list.Element
 	lruList  *list.List
 	capacity int
@@ -19,6 +21,8 @@ func newLruCache(capacity int) lruCache {
 }
 
 func (c *lruCache) clear() {
+	c.m.Lock()
+	defer c.m.Unlock()
 	c.values = make(map[interface{}]*list.Element)
 	c.lruList.Init()
 }
@@ -29,10 +33,14 @@ func (c *lruCache) add(value interface{}) bool {
 	if c.capacity == 0 {
 		return false
 	}
+	c.m.RLock()
+	defer c.m.RUnlock()
 	if e, ok := c.values[value]; ok {
 		c.lruList.MoveToFront(e)
 		return true
 	}
+	c.m.Lock()
+	defer c.m.Unlock()
 	for len(c.values) >= c.capacity {
 		oldest := c.lruList.Back()
 		delete(c.values, oldest.Value)


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Describe the solution you've provided**

We put LD libraries under the heavy load in production (>500M requests/24h) and the LRU cache starts panics, because it's not thread safe.

We're using the older version of library but the same code is there since a while.

Stack trace (at the bottom, there is a line 32 of lru_cache.go which produces a problem)
```
/go/pkg/mod/gopkg.in/launchdarkly/go-sdk-events.v1@v1.1.1/event_processor.go:145 +0x616
created by gopkg.in/launchdarkly/go-sdk-events%2ev1.startEventDispatcher in goroutine 525
/go/pkg/mod/gopkg.in/launchdarkly/go-sdk-events.v1@v1.1.1/event_processor.go:193 +0x4c9
gopkg.in/launchdarkly/go-sdk-events%2ev1.(*eventDispatcher).runMainLoop(0xc000b585a0, 0xc000ee8a80)
/go/pkg/mod/gopkg.in/launchdarkly/go-sdk-events.v1@v1.1.1/event_processor.go:263 +0x4ff
gopkg.in/launchdarkly/go-sdk-events%2ev1.(*eventDispatcher).processEvent(0xc000b585a0, {0x49834c0, 0xc0013bf408})
/go/pkg/mod/gopkg.in/launchdarkly/go-sdk-events.v1@v1.1.1/lru_cache.go:32 +0x45
gopkg.in/launchdarkly/go-sdk-events%2ev1.(*lruCache).add(0xc000b58728, {0x37e48a0, 0xc008de97f0})
goroutine 543 [running]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x476efd]
panic: runtime error: invalid memory address or nil pointer dereference
```

We think, there should be a `RWMutex` around that to avoid accessing invalid memory.

**Describe alternatives you've considered**

No other options.

**Additional context**

