### PR TITLE
chore: Add NoOpEventMetrics to eliminate nil checks

### DIFF
--- a/event_processor.go
+++ b/event_processor.go
@@ -74,6 +74,9 @@ const (
 
 // NewDefaultEventProcessor creates an instance of the default implementation of analytics event processing.
 func NewDefaultEventProcessor(config EventsConfiguration) EventProcessor {
+	if config.EventMetrics == nil {
+		config.EventMetrics = NoOpEventMetrics{}
+	}
 	inboxCh := make(chan eventDispatcherMessage, config.Capacity)
 	startEventDispatcher(config, inboxCh)
 	return &defaultEventProcessor{
@@ -138,10 +141,8 @@ func (ep *defaultEventProcessor) postNonBlockingMessageToInbox(e eventDispatcher
 	ep.inboxFullOnce.Do(func() { // COVERAGE: no way to simulate this condition in unit tests
 		ep.loggers.Warn("Events are being produced faster than they can be processed; some events will be dropped")
 	})
-	if ep.eventMetrics != nil {
-		if _, ok := e.(sendEventMessage); ok {
-			ep.eventMetrics.RecordDroppedEvents(1)
-		}
+	if _, ok := e.(sendEventMessage); ok {
+		ep.eventMetrics.RecordDroppedEvents(1)
 	}
 }
 
@@ -523,15 +524,13 @@ func runFlushTask(ctx context.Context, config EventsConfiguration, formatter *ev
 			bytes, count := formatter.makeOutputEvents(payload.events, payload.summary)
 			if len(bytes) > 0 {
 				result := config.EventSender.SendEventData(AnalyticsEventDataKind, bytes, count)
-				if config.EventMetrics != nil {
-					if result.Success {
-						config.EventMetrics.RecordEventsSent(count)
-						config.EventMetrics.RecordEventsBytesSent(len(bytes))
-					} else {
-						config.EventMetrics.RecordEventsFailedSend(count, EventSendFailureMetadata{
-							StatusCode: result.StatusCode,
-						})
-					}
+				if result.Success {
+					config.EventMetrics.RecordEventsSent(count)
+					config.EventMetrics.RecordEventsBytesSent(len(bytes))
+				} else {
+					config.EventMetrics.RecordEventsFailedSend(count, EventSendFailureMetadata{
+						StatusCode: result.StatusCode,
+					})
 				}
 
 				select {

--- a/interfaces.go
+++ b/interfaces.go
@@ -88,6 +88,17 @@ type EventMetrics interface {
 	RecordPendingEvents(count int)
 }
 
+// NoOpEventMetrics is a default implementation of EventMetrics that does nothing.
+// It is used when no EventMetrics is provided in EventsConfiguration, eliminating the
+// need for nil checks at every call site.
+type NoOpEventMetrics struct{}
+
+func (NoOpEventMetrics) RecordDroppedEvents(int)                              {}
+func (NoOpEventMetrics) RecordEventsSent(int)                                 {}
+func (NoOpEventMetrics) RecordEventsFailedSend(int, EventSendFailureMetadata) {}
+func (NoOpEventMetrics) RecordEventsBytesSent(int)                            {}
+func (NoOpEventMetrics) RecordPendingEvents(int)                              {}
+
 // EventSendFailureMetadata provides additional context about why an event batch failed to send.
 // This struct may be extended with additional fields in the future without breaking compatibility.
 type EventSendFailureMetadata struct {

--- a/outbox.go
+++ b/outbox.go
@@ -31,16 +31,12 @@ func (b *eventsOutbox) addEvent(event anyEventInput) {
 			b.loggers.Warn("Exceeded event queue capacity. Increase capacity to avoid dropping events.")
 		}
 		b.droppedEvents++
-		if b.eventMetrics != nil {
-			b.eventMetrics.RecordDroppedEvents(1)
-		}
+		b.eventMetrics.RecordDroppedEvents(1)
 		return
 	}
 	b.capacityExceeded = false
 	b.events = append(b.events, event)
-	if b.eventMetrics != nil {
-		b.eventMetrics.RecordPendingEvents(len(b.events))
-	}
+	b.eventMetrics.RecordPendingEvents(len(b.events))
 }
 
 func (b *eventsOutbox) addToSummary(ed EvaluationData) {
@@ -66,7 +62,5 @@ func (b *eventsOutbox) clear() {
 	}
 	b.events = b.events[0:0]
 	b.summarizer.reset()
-	if b.eventMetrics != nil {
-		b.eventMetrics.RecordPendingEvents(0)
-	}
+	b.eventMetrics.RecordPendingEvents(0)
 }


### PR DESCRIPTION
Add a no-op implementation of EventMetrics that is used as the default
when no EventMetrics is provided in EventsConfiguration. This removes
all nil checks at call sites, following the null object pattern.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: introduces a no-op `EventMetrics` default and removes nil guards, with behavior only changing in that metrics methods are now always invoked (but may no-op) when metrics are unset.
> 
> **Overview**
> Defaults `EventsConfiguration.EventMetrics` to a new `NoOpEventMetrics` implementation in `NewDefaultEventProcessor`, applying the null-object pattern.
> 
> Removes `nil` checks around metrics reporting throughout event enqueue/flush paths (`outbox` drops/pending counts, inbox overflow drops, and send success/failure reporting), relying on the no-op implementation when metrics are not configured.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea2ef797b9e3ac9791ac75e01c140b689548eecd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->