### PR TITLE
feat: mark override evaluations in summary counters and suppress their individual events

### DIFF
--- a/event_processor.go
+++ b/event_processor.go
@@ -324,8 +324,10 @@ func (ed *eventDispatcher) processEvent(evt anyEventInput) {
 			ed.outbox.addToSummary(evt)
 		}
 
-		willAddFullEvent = evt.RequireFullEvent
-		if ed.shouldDebugEvent(&evt) {
+		// Evaluations of override-supplied flag definitions are represented only in the
+		// summary counters, never as individual evaluation or debug events.
+		willAddFullEvent = evt.RequireFullEvent && !evt.IsOverride
+		if !evt.IsOverride && ed.shouldDebugEvent(&evt) {
 			de := evt
 			de.debug = true
 			debugEvent = de

--- a/event_processor_test.go
+++ b/event_processor_test.go
@@ -410,6 +410,55 @@ func TestIndividualFeatureEventIsQueuedWhenTrackEventsIsTrue(t *testing.T) {
 	})
 }
 
+func TestIndividualFeatureEventIsNotQueuedForOverrideEvaluation(t *testing.T) {
+	withAndWithoutPrivateAttrs(t, func(t *testing.T, config EventsConfiguration) {
+		ep, es := createEventProcessorAndSender(config)
+		defer ep.Close()
+
+		context := basicContext()
+		flag := FlagEventProperties{Key: "flagkey", Version: 11, RequireFullEvent: true, IsOverride: true}
+		fe := defaultEventFactory.NewEvaluationData(flag, context, testEvalDetailWithoutReason, false, ldvalue.Null(), "", ldvalue.OptionalInt{}, false)
+		require.True(t, fe.IsOverride)
+		ep.RecordEvaluation(fe)
+		ep.Flush()
+
+		// The evaluation is still summarized (in an override-marked counter) and still produces an
+		// index event, but no individual feature event even though RequireFullEvent is true.
+		assertEventsReceived(t, es,
+			anyIndexEvent(),
+			summaryEventWithFlag(flag,
+				append(summaryCounterPropsFromEval(testEvalDetailWithoutReason, 1),
+					m.JSONProperty("override").Should(m.Equal(true)))),
+		)
+		es.assertNoMoreEvents(t)
+	})
+}
+
+func TestDebugEventIsNotAddedForOverrideEvaluation(t *testing.T) {
+	fakeTimeNow := ldtime.UnixMillisecondTime(1000000)
+	config := basicConfigWithoutPrivateAttrs()
+	config.currentTimeProvider = func() ldtime.UnixMillisecondTime { return fakeTimeNow }
+	eventFactory := NewEventFactory(false, config.currentTimeProvider)
+
+	ep, es := createEventProcessorAndSender(config)
+	defer ep.Close()
+
+	context := basicContext()
+	futureTime := fakeTimeNow + 100
+	flag := FlagEventProperties{Key: "flagkey", Version: 11, DebugEventsUntilDate: futureTime, IsOverride: true}
+	fe := eventFactory.NewEvaluationData(flag, context, testEvalDetailWithoutReason, false, ldvalue.Null(), "", ldvalue.OptionalInt{}, false)
+	ep.RecordEvaluation(fe)
+	ep.Flush()
+
+	assertEventsReceived(t, es,
+		anyIndexEvent(),
+		summaryEventWithFlag(flag,
+			append(summaryCounterPropsFromEval(testEvalDetailWithoutReason, 1),
+				m.JSONProperty("override").Should(m.Equal(true)))),
+	)
+	es.assertNoMoreEvents(t)
+}
+
 func TestIndividualFeatureEventHasContextAttributesRedactedIfAnonymous(t *testing.T) {
 	withAndWithoutPrivateAttrs(t, func(t *testing.T, config EventsConfiguration) {
 		ep, es := createEventProcessorAndSender(config)

--- a/event_summarizer.go
+++ b/event_summarizer.go
@@ -29,6 +29,7 @@ type flagSummary struct {
 type counterKey struct {
 	variation ldvalue.OptionalInt
 	version   ldvalue.OptionalInt
+	override  bool
 }
 
 type counterValue struct {
@@ -62,7 +63,7 @@ func (s *eventSummarizer) summarizeEvent(ed EvaluationData) {
 		s.eventsState.flags[ed.Key] = flag
 	}
 
-	counterKey := counterKey{variation: ed.Variation, version: ed.Version}
+	counterKey := counterKey{variation: ed.Variation, version: ed.Version, override: ed.IsOverride}
 	if value, ok := flag.counters[counterKey]; ok {
 		value.count++
 	} else {

--- a/event_summarizer_test.go
+++ b/event_summarizer_test.go
@@ -64,22 +64,22 @@ func TestSummarizeEventIncrementsCounters(t *testing.T) {
 			defaultValue: ldvalue.String("default1"),
 			contextKinds: map[ldcontext.Kind]struct{}{ldcontext.DefaultKind: {}},
 			counters: map[counterKey]*counterValue{
-				{variation1, flagVersion1}: {2, ldvalue.String("value1")},
-				{variation2, flagVersion1}: {1, ldvalue.String("value2")},
+				{variation: variation1, version: flagVersion1}: {2, ldvalue.String("value1")},
+				{variation: variation2, version: flagVersion1}: {1, ldvalue.String("value2")},
 			},
 		},
 		flagKey2: {
 			defaultValue: ldvalue.String("default2"),
 			contextKinds: map[ldcontext.Kind]struct{}{ldcontext.DefaultKind: {}},
 			counters: map[counterKey]*counterValue{
-				{variation1, flagVersion2}: {1, ldvalue.String("value99")},
+				{variation: variation1, version: flagVersion2}: {1, ldvalue.String("value99")},
 			},
 		},
 		unknownFlagKey: {
 			defaultValue: ldvalue.String("default3"),
 			contextKinds: map[ldcontext.Kind]struct{}{ldcontext.DefaultKind: {}},
 			counters: map[counterKey]*counterValue{
-				{undefInt, undefInt}: {1, ldvalue.String("default3")},
+				{variation: undefInt, version: undefInt}: {1, ldvalue.String("default3")},
 			},
 		},
 	}
@@ -104,9 +104,36 @@ func TestCounterForNilVariationIsDistinctFromOthers(t *testing.T) {
 			defaultValue: ldvalue.String("default1"),
 			contextKinds: map[ldcontext.Kind]struct{}{ldcontext.DefaultKind: {}},
 			counters: map[counterKey]*counterValue{
-				{variation1, flagVersion}: {1, ldvalue.String("value1")},
-				{variation2, flagVersion}: {1, ldvalue.String("value2")},
-				{undefInt, flagVersion}:   {1, ldvalue.String("default1")},
+				{variation: variation1, version: flagVersion}: {1, ldvalue.String("value1")},
+				{variation: variation2, version: flagVersion}: {1, ldvalue.String("value2")},
+				{variation: undefInt, version: flagVersion}:   {1, ldvalue.String("default1")},
+			},
+		},
+	}
+	assert.Equal(t, expectedFlags, data.flags)
+}
+
+func TestCounterForOverrideIsDistinctFromNonOverride(t *testing.T) {
+	es := newEventSummarizer()
+	flagKey := "key1"
+	flagVersion := ldvalue.NewOptionalInt(11)
+	variation := ldvalue.NewOptionalInt(1)
+	event1 := makeEvalEvent(0, flagKey, flagVersion, variation, "value1", "default1")
+	event2 := makeEvalEvent(0, flagKey, flagVersion, variation, "value1", "default1")
+	event2.IsOverride = true
+	event3 := makeEvalEvent(0, flagKey, flagVersion, variation, "value1", "default1")
+	for _, e := range []EvaluationData{event1, event2, event3} {
+		es.summarizeEvent(e)
+	}
+	data := es.snapshot()
+
+	expectedFlags := map[string]flagSummary{
+		flagKey: {
+			defaultValue: ldvalue.String("default1"),
+			contextKinds: map[ldcontext.Kind]struct{}{ldcontext.DefaultKind: {}},
+			counters: map[counterKey]*counterValue{
+				{variation: variation, version: flagVersion}:                 {2, ldvalue.String("value1")},
+				{variation: variation, version: flagVersion, override: true}: {1, ldvalue.String("value1")},
 			},
 		},
 	}
@@ -134,15 +161,15 @@ func TestSummaryContextKindsAreTrackedPerFlag(t *testing.T) {
 			defaultValue: ldvalue.String("default1"),
 			contextKinds: map[ldcontext.Kind]struct{}{ldcontext.DefaultKind: {}, "org": {}},
 			counters: map[counterKey]*counterValue{
-				{variation1, flagVersion1}: {2, ldvalue.String("value1")},
-				{variation2, flagVersion1}: {1, ldvalue.String("value2")},
+				{variation: variation1, version: flagVersion1}: {2, ldvalue.String("value1")},
+				{variation: variation2, version: flagVersion1}: {1, ldvalue.String("value2")},
 			},
 		},
 		flagKey2: {
 			defaultValue: ldvalue.String("default2"),
 			contextKinds: map[ldcontext.Kind]struct{}{ldcontext.DefaultKind: {}},
 			counters: map[counterKey]*counterValue{
-				{variation1, flagVersion2}: {1, ldvalue.String("value99")},
+				{variation: variation1, version: flagVersion2}: {1, ldvalue.String("value99")},
 			},
 		},
 	}

--- a/events_output.go
+++ b/events_output.go
@@ -220,6 +220,7 @@ func (ef eventOutputFormatter) writeSummaryEvent(w *jwriter.Writer, snapshot eve
 			} else {
 				counterObj.Name("unknown").Bool(true)
 			}
+			counterObj.Maybe("override", counterKey.override).Bool(counterKey.override)
 			counterValue.flagValue.WriteToJSONWriter(counterObj.Name("value"))
 			counterObj.Name("count").Int(counterValue.count)
 			counterObj.End()

--- a/events_output_test.go
+++ b/events_output_test.go
@@ -436,6 +436,33 @@ func TestEventOutputSummaryEvents(t *testing.T) {
 			}))
 	})
 
+	t.Run("summary - override counters", func(t *testing.T) {
+		flag1v1Override := flag1v1
+		flag1v1Override.IsOverride = true
+
+		es := newEventSummarizer()
+		es.summarizeEvent(withoutReasons.NewEvaluationData(flag1v1Override, user,
+			ldreason.NewEvaluationDetail(ldvalue.String("v"), 1, noReason),
+			false, ldvalue.String("dv"), "", ldvalue.OptionalInt{}, false))
+		es.summarizeEvent(withoutReasons.NewEvaluationData(flag1v1, user,
+			ldreason.NewEvaluationDetail(ldvalue.String("v"), 1, noReason),
+			false, ldvalue.String("dv"), "", ldvalue.OptionalInt{}, false))
+
+		bytes, count := formatter.makeOutputEvents(nil, es.snapshot())
+		require.Equal(t, 1, count)
+
+		// The override marker appears only on the override counter, and the two counters stay
+		// separate even though the flag key, variation, and version are identical.
+		m.In(t).Assert(bytes, m.JSONArray().Should(m.Items(
+			m.JSONProperty("features").Should(m.JSONProperty("flag1").Should(
+				m.JSONProperty("counters").Should(m.ItemsInAnyOrder(
+					m.JSONEqual(json.RawMessage(`{"count":1,"value":"v","variation":1,"version":100,"override":true}`)),
+					m.JSONEqual(json.RawMessage(`{"count":1,"value":"v","variation":1,"version":100}`)),
+				)),
+			)),
+		)))
+	})
+
 	t.Run("summary - multiple counters", func(t *testing.T) {
 		es := newEventSummarizer()
 		es.summarizeEvent(withoutReasons.NewEvaluationData(flag1v1, user, ldreason.NewEvaluationDetail(ldvalue.String("a"), 1, noReason),

--- a/inputs.go
+++ b/inputs.go
@@ -77,6 +77,10 @@ type EvaluationData struct {
 	ForceSampling bool
 	// ExcludeFromSummaries determines if the event should be included in summary calculations.
 	ExcludeFromSummaries bool
+	// IsOverride is true if the flag definition that was evaluated came from an SDK override source
+	// rather than from LaunchDarkly. Override evaluations are aggregated into separate summary
+	// counters carrying an override marker, and do not produce individual evaluation or debug events.
+	IsOverride bool
 	// debug is true if this is a copy of an evaluation event that we have queued to be output as a debug
 	// event. This field is not exported because it is never part of the input parameters from the application;
 	// we debug events only internally, based on DebugEventsUntilDate.
@@ -155,6 +159,9 @@ type FlagEventProperties struct {
 	// DebugEventsUntilDate is non-zero if event debugging has been temporarily enabled for the flag. It is the
 	// time at which debugging mode should expire.
 	DebugEventsUntilDate ldtime.UnixMillisecondTime
+	// IsOverride is true if the flag definition came from an SDK override source rather than from
+	// LaunchDarkly.
+	IsOverride bool
 }
 
 // EventFactory is a configurable factory for event objects.
@@ -229,6 +236,7 @@ func (f EventFactory) NewEvaluationData(
 		DebugEventsUntilDate: flagProps.DebugEventsUntilDate,
 		SamplingRatio:        samplingRatio,
 		ExcludeFromSummaries: excludeFromSummaries,
+		IsOverride:           flagProps.IsOverride,
 	}
 	if f.includeReasons || isExperiment {
 		ed.Reason = detail.Reason


### PR DESCRIPTION
Adds events-pipeline support for evaluations of flag definitions supplied by an SDK override source (OVERRIDE spec):

- `FlagEventProperties` and `EvaluationData` gain an `IsOverride` field. It rides along through `NewEvaluationData`, whose signature is unchanged, so existing callers (including ld-relay) are unaffected.
- The summary counter aggregation key now includes the override state, so override and non-override evaluations of the same flag key, variation, and version accumulate into separate counters rather than collapsing together.
- Summary output writes `"override": true` on override counters, mirroring the existing `unknown` marker; it is omitted otherwise, so existing summary output is unchanged byte-for-byte.
- Override evaluations never produce individual feature events or debug events, even when the flag has `trackEvents`/debug enabled. They are still summarized and still produce index events.

Note for reviewers: event ingestion needs to recognize the `override` counter marker before an SDK release carrying this reaches customers; that dependency is tracked on the epic. Existing summarizer tests switched to named-field counter-key literals because the key gained a field.

SDK-2653

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes analytics summary payload shape and suppresses some events for override evaluations; non-override behavior stays byte-compatible, but ingestion must understand the new `override` counter field before rollout.
> 
> **Overview**
> Adds **`IsOverride`** on `FlagEventProperties` and `EvaluationData` (wired through `NewEvaluationData` without API signature changes) for evaluations against SDK-supplied flag definitions instead of LaunchDarkly.
> 
> **Summary aggregation** now keys counters by override state as well as variation and version, so override and normal evaluations of the same flag do not merge. Summary JSON emits **`"override": true`** only on override counters (omitted otherwise), matching the existing `unknown` pattern.
> 
> **Event processor** still summarizes override evaluations and still emits index events, but **never** queues individual feature or debug events for them—even when `RequireFullEvent` or debug mode would normally apply.
> 
> Tests cover summarizer separation, summary output, and processor behavior for track-events and debug paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8af496ae2ab592e8b18227c3dcd407b57f8294f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->