### PR TITLE
ci: pass untrusted workflow data through quoted env vars

### DIFF
--- a/.github/workflows/check-go-versions.yml
+++ b/.github/workflows/check-go-versions.yml
@@ -4,15 +4,18 @@ on:
     - cron: "0 17 * * *"
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   check-go-eol:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       latest: ${{ steps.parse.outputs.latest }}
       penultimate: ${{ steps.parse.outputs.penultimate }}
     timeout-minutes: 2
     steps:
-      - uses: actions/checkout@v7
         # Perform a GET request to endoflife.date for the Go language. The response
         # contains all Go releases; we're interested in the 0'th and 1'th (latest and penultimate.)
       - name: Fetch officially supported Go versions
@@ -24,9 +27,20 @@ jobs:
         # Parse the response JSON and insert into environment variables for the next step.
       - name: Parse officially supported Go versions
         id: parse
+        env:
+          FETCH_API_DATA: ${{ env.fetchApiData }}
         run: |
-          echo "latest=${{ fromJSON(env.fetchApiData)[0].cycle }}" >> $GITHUB_OUTPUT
-          echo "penultimate=${{ fromJSON(env.fetchApiData)[1].cycle }}" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          latest=$(jq -r '.[0].cycle' <<< "$FETCH_API_DATA")
+          penultimate=$(jq -r '.[1].cycle' <<< "$FETCH_API_DATA")
+          for version in "$latest" "$penultimate"; do
+            if [[ ! "$version" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
+              echo "Unexpected Go version string from endoflife.date: $version" >&2
+              exit 1
+            fi
+          done
+          echo "latest=$latest" >> "$GITHUB_OUTPUT"
+          echo "penultimate=$penultimate" >> "$GITHUB_OUTPUT"
 
 
   create-prs:
@@ -49,14 +63,15 @@ jobs:
 
       - name: Get current Go versions
         id: go-versions
-        run:  cat ./.github/variables/go-versions.env > $GITHUB_OUTPUT
+        run:  cat ./.github/variables/go-versions.env >> "$GITHUB_OUTPUT"
 
       - name: Update go-versions.env and README.md
         if: steps.go-versions.outputs.latest != env.officialLatestVersion
         id: update-go-versions
         run: |
-          sed -i -e "s#latest=[^ ]*#latest=${{ env.officialLatestVersion }}#g" \
-                 -e "s#penultimate=[^ ]*#penultimate=${{ env.officialPenultimateVersion }}#g" \
+          set -euo pipefail
+          sed -i -e "s#latest=[^ ]*#latest=$officialLatestVersion#g" \
+                 -e "s#penultimate=[^ ]*#penultimate=$officialPenultimateVersion#g" \
                   ./.github/variables/go-versions.env
 
       - name: Create pull request


### PR DESCRIPTION
Removes a GitHub Actions script-injection vector in `check-go-versions.yml` by moving untrusted endoflife.date response data out of `${{ }}` shell interpolation into a quoted env var, with `jq` extraction and strict version validation.

Ports the same fix as launchdarkly/ld-relay#841 (SEC-9481).

The `check-go-eol` job fetched `https://endoflife.date/api/go.json` and spliced the raw response into a `run:` block via `${{ fromJSON(env.fetchApiData)[N].cycle }}`, so bash received it as *script text*. A malicious or compromised upstream response could execute arbitrary commands in a workflow whose downstream job holds `contents: write` + `pull-requests: write`.

**What changed in this repo**

- Added top-level `permissions: {}` so no job gets implicit token scopes.
- Scoped `check-go-eol` to `permissions: { contents: read }`.
- Dropped the unused `actions/checkout@v7` step from `check-go-eol` — that job only fetches and parses JSON and never touches the repo. The checkout in `create-prs` is untouched.
- Rewrote the parse step to bind `${{ env.fetchApiData }}` into a `FETCH_API_DATA` env var, extract `.cycle` with `jq -r`, and validate both values against `^[0-9]+\.[0-9]+(\.[0-9]+)?$`, failing the job on anything unexpected. Nothing untrusted reaches the shell as code anymore.
- `Get current Go versions` now appends (`>> "$GITHUB_OUTPUT"`) instead of truncating (`> $GITHUB_OUTPUT`) a file the runner owns.
- Hardened the update step (not needed in the relay PR): the `sed` command used `${{ env.officialLatestVersion }}` / `${{ env.officialPenultimateVersion }}` interpolation. Those are already job-level `env:`, so the script now references `"$officialLatestVersion"` / `"$officialPenultimateVersion"` directly, plus `set -euo pipefail`.

The `create-pull-request` `branch:`/`title:`/`commit-message:` inputs still use `${{ }}` — that is not a shell context, and the values are now validated by the parse step, so they were left alone. No action pins were bumped and no unrelated YAML was reformatted.

**Verification**

- YAML parses: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/check-go-versions.yml'))"` → OK.
- `grep -n '\${{'` on the file: every remaining hit is in an `outputs:` / `env:` / `with:` / `ref:` context; none inside a `run:` script body.
- Live payload: `FETCH_API_DATA=$(curl -sS https://endoflife.date/api/go.json)` through the new logic yields `latest=1.27`, `penultimate=1.26` — matching the values the old expression produced.
- Hostile payload: `[{"cycle":"1.27; touch /tmp/pwned"},{"cycle":"1.26"}]` is rejected — the validation loop prints `Unexpected Go version string from endoflife.date: 1.27; touch /tmp/pwned` and exits 1, and `/tmp/pwned` is never created.
- `git diff` touches only `.github/workflows/check-go-versions.yml`.

**Requirements**

- [x] I have added test coverage for new or changed functionality — n/a — workflow-only change
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Hardens **`.github/workflows/check-go-versions.yml`** against GitHub Actions script injection when consuming **endoflife.date** API data, and tightens token permissions for the scheduled Go version check.
> 
> The **`check-go-eol`** job no longer splices `${{ fromJSON(env.fetchApiData)... }}` into shell scripts. Parsed versions flow through a quoted **`FETCH_API_DATA`** env var, **`jq`** extraction, and a regex gate (`^[0-9]+\.[0-9]+(\.[0-9]+)?$`) that fails the job on unexpected strings. Top-level **`permissions: {}`** and job-level **`contents: read`** on **`check-go-eol`** replace implicit broad scopes; the unused **`actions/checkout`** step is removed from that job.
> 
> In **`create-prs`**, **`go-versions.env`** is appended to **`GITHUB_OUTPUT`** instead of overwriting it, and the **`sed`** update step uses **`set -euo pipefail`** plus **`$officialLatestVersion`** / **`$officialPenultimateVersion`** from job **`env`** instead of `${{ }}` inside the script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8eddbcf3028490e6b113b63cae66db6f29004e98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->